### PR TITLE
Change assertThat to check the String rather than list.

### DIFF
--- a/src/test/java/io/fabric8/quickstarts/camel/ApplicationTest.java
+++ b/src/test/java/io/fabric8/quickstarts/camel/ApplicationTest.java
@@ -71,9 +71,7 @@ public class ApplicationTest {
         assertThat(booksResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
         List<Book> books = booksResponse.getBody();
         assertThat(books).hasSize(2);
-        assertThat(books).element(0)
-            .hasFieldOrPropertyWithValue("description", "ActiveMQ in Action");
-        assertThat(books).element(1)
-            .hasFieldOrPropertyWithValue("description", "Camel in Action");
+        assertThat(books.get(0).getDescription()).isIn("ActiveMQ in Action");
+        assertThat(books.get(1).getDescription()).isIn("Camel in Action");
     }
 }


### PR DESCRIPTION
Getting this error on ApplicationTest.java - need to tweak the way we use assertThat.

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.0:testCompile (default-testCompile) on project spring-boot-camel-rest-sql: Compilation failure: Compilation failure:
[ERROR] /home/jenkins/spring-boot-camel-rest-sql/src/test/java/io/fabric8/quickstarts/camel/ApplicationTest.java:[74,26] cannot find symbol
[ERROR] symbol:   method element(int)
[ERROR] location: class org.assertj.core.api.AbstractListAssert<capture#1 of ?,capture#2 of ? extends java.util.List<? extends io.fabric8.quickstarts.camel.Book>,io.fabric8.quickstarts.camel.Book>
[ERROR] /home/jenkins/spring-boot-camel-rest-sql/src/test/java/io/fabric8/quickstarts/camel/ApplicationTest.java:[76,26] cannot find symbol
[ERROR] symbol:   method element(int)
[ERROR] location: class org.assertj.core.api.AbstractListAssert<capture#3 of ?,capture#4 of ? extends java.util.List<? extends io.fabric8.quickstarts.camel.Book>,io.fabric8.quickstarts.camel.Book>
[ERROR] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.0:testCompile (default-testCompile) on project spring-boot-camel-rest-sql: Compilation failure