### PR TITLE
[ENTESB-15424]Quickstarts don't expose routes on OCP 4.x

### DIFF
--- a/src/main/jkube/route.yml
+++ b/src/main/jkube/route.yml
@@ -1,3 +1,6 @@
+
+apiVersion: "route.openshift.io/v1"
+kind: Route
 spec:
   to:
     kind: Service


### PR DESCRIPTION
(cherry picked from commit 05c302baf32e52b0233f8ca2ed3d23f896a67730)